### PR TITLE
Add package description

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - pyclean = pyclean.cli:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -38,6 +38,68 @@ about:
   license: GPL-3.0-or-later
   license_file: LICENSE
   summary: Pure Python cross-platform pyclean. Clean up your Python bytecode.
+  description: |
+    Worried about `.pyc` files and `__pycache__` directories? Fear not!
+    PyClean is here to help. Finally the single-command clean up for Python
+    bytecode files in your favorite directories. On any platform.
+
+    ```shell
+    pyclean .
+    pyclean . --dry-run --verbose
+    pyclean --help
+    ```
+
+    PyClean can clean up leftovers, generated data and temporary files from
+    popular Python development tools in their default locations, along with
+    Python bytecode. The following topics are currently covered:
+
+    - Cache (general purpose folder for several tools, e.g. Python eggs,
+      legacy Pytest)
+    - Coverage (coverage database, and supported file formats)
+    - Packaging (build files and folders)
+    - Pytest (build files and folders)
+    - Ruff (ruff cache folder)
+    - Jupyter (notebook checkpoints) – _optional_
+    - Mypy (mypy cache folder) – _optional_
+    - Tox (tox environments) – _optional_
+
+    ```shell
+    pyclean . --debris
+    pyclean . -d jupyter -n -v
+    ```
+
+    PyClean also lets you remove free-form targets using globbing. Note that
+    this is potentially dangerous: You can delete everything anywhere in the
+    file system, including the entire project you’re working on. For this
+    reason, the `--erase` option has a few artificial constraints:
+
+    - It doesn’t do recursive deletion by itself, which means that you have
+      to specify the directory and its contents, separately and explicitly.
+    - The above entails that you’re responsible for the deletion order,
+      i.e. removal of a directory will only work if you asked to delete all
+      files inside first.
+    - You’re prompted interactively to confirm deletion, unless you specify
+      the `--yes` option, in addition.
+
+    ```shell
+    pyclean . --erase tmp/**/* tmp/
+    ```
+
+    If you want to avoid installing `pyclean` you can add it to your
+    `tox.ini` as a new environment.
+
+    ```ini
+    # [testenv:clean]
+    skip_install = true
+    deps = pyclean
+    commands = pyclean {posargs:. --debris}
+    ```
+
+    You’ll then be able to run it with [Tox](https://tox.wiki/) like this:
+
+    ```shell
+    tox -e clean
+    ```
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
On Anaconda.org, the [conda-forge package](https://anaconda.org/conda-forge/pyclean) description is empty unless populated in `meta.yaml`.

This change populates the _Description_ section of the conda-forge package page. The section content is meant to serve as usage instructions for users that are not used to asking a CLI command for `--help`.

## Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
