### PR TITLE
Make code blocks display nicer in description

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - pyclean = pyclean.cli:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -43,11 +43,13 @@ about:
     PyClean is here to help. Finally the single-command clean up for Python
     bytecode files in your favorite directories. On any platform.
 
+    <p>
     ```shell
     pyclean .
     pyclean . --dry-run --verbose
     pyclean --help
     ```
+    </p>
 
     PyClean can clean up leftovers, generated data and temporary files from
     popular Python development tools in their default locations, along with
@@ -63,10 +65,12 @@ about:
     - Mypy (mypy cache folder) – _optional_
     - Tox (tox environments) – _optional_
 
+    <p>
     ```shell
     pyclean . --debris
     pyclean . -d jupyter -n -v
     ```
+    </p>
 
     PyClean also lets you remove free-form targets using globbing. Note that
     this is potentially dangerous: You can delete everything anywhere in the
@@ -81,25 +85,32 @@ about:
     - You’re prompted interactively to confirm deletion, unless you specify
       the `--yes` option, in addition.
 
+    <p>
     ```shell
     pyclean . --erase tmp/**/* tmp/
     ```
+    </p>
 
     If you want to avoid installing `pyclean` you can add it to your
     `tox.ini` as a new environment.
 
+    <p>
     ```ini
-    # [testenv:clean]
+    (testenv:clean)
     skip_install = true
     deps = pyclean
     commands = pyclean {posargs:. --debris}
     ```
+    </p>
 
     You’ll then be able to run it with [Tox](https://tox.wiki/) like this:
 
+    <p>
     ```shell
     tox -e clean
     ```
+    </p>
+  doc_url: https://pypi.org/project/pyclean/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Code blocks in the description don't have paragraph spacing around them on conda-forge, by default. This makes the instructions a bit awkward to read.

Hence, we wrap an HTML paragraph block around them, and we also add a link to the canonical description and usage instructions on PyPI.

## Checklist

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.